### PR TITLE
Fill value fixes for V3

### DIFF
--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -464,7 +464,6 @@ class CFMaskCoder(VariableCoder):
                 dtype, decoded_fill_value = np.int64, np.iinfo(np.int64).min
             else:
                 if "scale_factor" not in attrs and "add_offset" not in attrs:
-                    print(data.dtype)
                     dtype, decoded_fill_value = dtypes.maybe_promote(data.dtype)
                 else:
                     dtype, decoded_fill_value = (
@@ -704,6 +703,19 @@ class ObjectVLenStringCoder(VariableCoder):
         if variable.dtype.kind == "O" and variable.encoding.get("dtype", False) is str:
             variable = variable.astype(variable.encoding["dtype"])
             return variable
+        else:
+            return variable
+
+
+class Numpy2StringDTypeCoder(VariableCoder):
+    # Convert Numpy 2 StringDType arrays to object arrays for backwards compatibility
+    # TODO: remove this if / when we decide to allow StringDType arrays in Xarray
+    def encode(self):
+        raise NotImplementedError
+
+    def decode(self, variable: Variable, name: T_Name = None) -> Variable:
+        if variable.dtype.kind == "T":
+            return variable.astype(object)
         else:
             return variable
 

--- a/xarray/coding/variables.py
+++ b/xarray/coding/variables.py
@@ -464,6 +464,7 @@ class CFMaskCoder(VariableCoder):
                 dtype, decoded_fill_value = np.int64, np.iinfo(np.int64).min
             else:
                 if "scale_factor" not in attrs and "add_offset" not in attrs:
+                    print(data.dtype)
                     dtype, decoded_fill_value = dtypes.maybe_promote(data.dtype)
                 else:
                     dtype, decoded_fill_value = (

--- a/xarray/conventions.py
+++ b/xarray/conventions.py
@@ -276,6 +276,9 @@ def decode_cf_variable(
         var = variables.ObjectVLenStringCoder().decode(var)
         original_dtype = var.dtype
 
+    if original_dtype.kind == "T":
+        var = variables.Numpy2StringDTypeCoder().decode(var)
+
     if mask_and_scale:
         for coder in [
             variables.CFMaskCoder(),

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -61,7 +61,6 @@ def maybe_promote(dtype: np.dtype) -> tuple[np.dtype, Any]:
     # N.B. these casting rules should match pandas
     dtype_: np.typing.DTypeLike
     fill_value: Any
-    print("maybe_promote", dtype)
     if np.issubdtype(dtype, np.dtypes.StringDType()):
         # for now, we always promote string dtypes to object for consistency with existing behavior
         # TODO: refactor this once we have a better way to handle numpy vlen-string dtypes
@@ -202,7 +201,6 @@ def isdtype(dtype, kind: str | tuple[str, ...], xp=None) -> bool:
 
     Unlike xp.isdtype(), kind must be a string.
     """
-    print(dtype, kind, xp)
     # TODO(shoyer): remove this wrapper when Xarray requires
     # numpy>=2 and pandas extensions arrays are implemented in
     # Xarray via the array API

--- a/xarray/core/dtypes.py
+++ b/xarray/core/dtypes.py
@@ -61,7 +61,13 @@ def maybe_promote(dtype: np.dtype) -> tuple[np.dtype, Any]:
     # N.B. these casting rules should match pandas
     dtype_: np.typing.DTypeLike
     fill_value: Any
-    if isdtype(dtype, "real floating"):
+    print("maybe_promote", dtype)
+    if np.issubdtype(dtype, np.dtypes.StringDType()):
+        # for now, we always promote string dtypes to object for consistency with existing behavior
+        # TODO: refactor this once we have a better way to handle numpy vlen-string dtypes
+        dtype_ = object
+        fill_value = np.nan
+    elif isdtype(dtype, "real floating"):
         dtype_ = dtype
         fill_value = np.nan
     elif np.issubdtype(dtype, np.timedelta64):
@@ -196,6 +202,7 @@ def isdtype(dtype, kind: str | tuple[str, ...], xp=None) -> bool:
 
     Unlike xp.isdtype(), kind must be a string.
     """
+    print(dtype, kind, xp)
     # TODO(shoyer): remove this wrapper when Xarray requires
     # numpy>=2 and pandas extensions arrays are implemented in
     # Xarray via the array API

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -558,6 +558,7 @@ class DatasetIOBase:
                 # This currently includes all netCDF files when encoding is not
                 # explicitly set.
                 # https://github.com/pydata/xarray/issues/1647
+                # Also Zarr
                 expected["bytes_nans"][-1] = b""
                 expected["strings_nans"][-1] = ""
                 assert_identical(expected, actual)
@@ -2265,7 +2266,6 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             self.save(data, store_target, **save_kwargs)
             with self.open(store_target, **open_kwargs) as ds:
-                assert False
                 yield ds
 
     @pytest.mark.parametrize("consolidated", [False, True, None])
@@ -2745,12 +2745,12 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             import numcodecs
 
-            compressor = numcodecs.Blosc()
-
             if have_zarr_v3 and zarr.config.config["default_zarr_version"] == 3:
+                compressor = zarr.codecs.BloscCodec()
                 encoding_key = "codecs"
-                encoding_value = [compressor]
+                encoding_value = [zarr.codecs.BytesCodec(), compressor]
             else:
+                compressor = numcodecs.Blosc()
                 encoding_key = "compressor"
                 encoding_value = compressor
 

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -3164,38 +3164,6 @@ class ZarrBase(CFEncodedBase):
                 assert original[name].chunks == actual_var.chunks
             assert original.chunks == actual.chunks
 
-    def test_write_store(self) -> None:
-        skip_if_zarr_format_3(reason="unsupported dtypes")
-        return super().test_write_store()
-
-    def test_roundtrip_endian(self) -> None:
-        skip_if_zarr_format_3(reason="unsupported dtypes")
-        return super().test_roundtrip_endian()
-
-    def test_roundtrip_bytes_with_fill_value(self) -> None:
-        skip_if_zarr_format_3(reason="unsupported dtypes")
-        return super().test_roundtrip_bytes_with_fill_value()
-
-    def test_default_fill_value(self) -> None:
-        skip_if_zarr_format_3(reason="fill_value always written")
-        return super().test_default_fill_value()
-
-    def test_explicitly_omit_fill_value(self) -> None:
-        skip_if_zarr_format_3(reason="fill_value always written")
-        return super().test_explicitly_omit_fill_value()
-
-    def test_explicitly_omit_fill_value_via_encoding_kwarg(self) -> None:
-        skip_if_zarr_format_3(reason="fill_value always written")
-        return super().test_explicitly_omit_fill_value_via_encoding_kwarg()
-
-    def test_explicitly_omit_fill_value_in_coord(self) -> None:
-        skip_if_zarr_format_3(reason="fill_value always written")
-        return super().test_explicitly_omit_fill_value_in_coord()
-
-    def test_explicitly_omit_fill_value_in_coord_via_encoding_kwarg(self) -> None:
-        skip_if_zarr_format_3(reason="fill_value always written")
-        return super().test_explicitly_omit_fill_value_in_coord_via_encoding_kwarg()
-
 
 @requires_zarr
 @pytest.mark.skipif(not have_zarr_v3, reason="requires zarr version 3")

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2242,7 +2242,7 @@ class ZarrBase(CFEncodedBase):
     def save(self, dataset, store_target, **kwargs):  # type: ignore[override]
         if have_zarr_v3 and zarr.config.config["default_zarr_version"] == 3:
             for k, v in dataset.variables.items():
-                if v.dtype.kind in ("U", "O", "M", "b"):
+                if v.dtype.kind in ("M",):
                     pytest.skip(reason=f"Unsupported dtype {v} for variable: {k}")
 
         return dataset.to_zarr(store=store_target, **kwargs, **self.version_kwargs)
@@ -2265,6 +2265,7 @@ class ZarrBase(CFEncodedBase):
         with self.create_zarr_target() as store_target:
             self.save(data, store_target, **save_kwargs)
             with self.open(store_target, **open_kwargs) as ds:
+                assert False
                 yield ds
 
     @pytest.mark.parametrize("consolidated", [False, True, None])


### PR DESCRIPTION
This gets many of the backend tests passing against V3. Still some work to go.

Main issues addressed:

- only use fill_value for signaling missing data in V2 data via `use_zarr_fill_value_as_mask` parameter
- add new `Numpy2StringDTypeCoder` to deal with StringDType data coming out of Zarr

Summary of failures (many V2 due to https://github.com/zarr-developers/zarr-python/issues/2315)

```
$ pytest -v xarray/tests/test_backends.py::TestZarrDictStore
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_roundtrip_object_dtype[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_roundtrip_empty_vlen_string_array[2] - AssertionError: assert dtype('<U') == dtype('<U1')
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_write_persistence_modes[2-None] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_write_persistence_modes[2-group1] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_check_encoding_is_consistent_after_append[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_with_new_variable[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_with_append_dim_no_overwrite[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_to_zarr_append_compute_false_roundtrip[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_roundtrip_bytes_with_fill_value[3] - TypeError: Invalid attribute in Dataset.attrs.
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_roundtrip_endian[3] - KeyError: '>i2'
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_default_fill_value[3] - TypeError: must be real number, not str
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_explicitly_omit_fill_value_via_encoding_kwarg[3] - ValueError: unexpected encoding parameters for zarr backend:  ['_FillValue']
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_explicitly_omit_fill_value_in_coord_via_encoding_kwarg[3] - ValueError: unexpected encoding parameters for zarr backend:  ['_FillValue']
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_string_length_mismatch_raises[3-U] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_string_length_mismatch_raises[3-S] - Failed: DID NOT RAISE <class 'ValueError'>
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_check_encoding_is_consistent_after_append[3] - AttributeError: 'list' object has no attribute 'get_config'
```
