### PR TITLE
Fix test_roundtrip_empty_vlen_string_array

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -924,7 +924,8 @@ class CFEncodedBase(DatasetIOBase):
                 if actual["a"].dtype.metadata is not None:
                     assert check_vlen_dtype(actual["a"].dtype) is str
             else:
-                assert actual["a"].dtype == np.dtype("=U1")
+                # zarr v3 sends back "<U1"
+                assert np.issubdtype(actual["a"].dtype, np.dtype("=U1"))
 
     @pytest.mark.parametrize(
         "decoded_fn, encoded_fn",


### PR DESCRIPTION
Slightly relaxing the endianness requirement fixes `test_roundtrip_empty_vlen_string_array`