### PR TITLE
skip roundtrip_endian for zarr v3

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1224,6 +1224,7 @@ class CFEncodedBase(DatasetIOBase):
                 assert "coordinates" not in ds["lon"].encoding
 
     def test_roundtrip_endian(self) -> None:
+        skip_if_zarr_format_3("zarr v3 has not implemented endian support yet")
         ds = Dataset(
             {
                 "x": np.arange(3, 10, dtype=">i2"),


### PR DESCRIPTION
Endianness is basically not implemented in Zarr V3. These tests should be skipped for now.