### PR TITLE
All fixes combined

### DIFF
--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2787,12 +2787,18 @@ class ZarrBase(CFEncodedBase):
 
             encoding = {"da": {encoding_key: encoding_value}}
             ds.to_zarr(store_target, mode="w", encoding=encoding, **self.version_kwargs)
+            original_ds = xr.open_dataset(
+                store_target, engine="zarr", **self.version_kwargs
+            )
+            original_encoding = original_ds["da"].encoding[encoding_key]
             ds_to_append.to_zarr(store_target, append_dim="time", **self.version_kwargs)
             actual_ds = xr.open_dataset(
                 store_target, engine="zarr", **self.version_kwargs
             )
+            # assert actual_encoding.get_config() == compressor.get_config()
+            # TODO: check whether this approach works for v2
             actual_encoding = actual_ds["da"].encoding[encoding_key]
-            assert actual_encoding.get_config() == compressor.get_config()
+            assert original_encoding == actual_encoding
             assert_identical(
                 xr.open_dataset(
                     store_target, engine="zarr", **self.version_kwargs

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -924,7 +924,8 @@ class CFEncodedBase(DatasetIOBase):
                 if actual["a"].dtype.metadata is not None:
                     assert check_vlen_dtype(actual["a"].dtype) is str
             else:
-                assert actual["a"].dtype == np.dtype("=U1")
+                # zarr v3 sends back "<U1"
+                assert np.issubdtype(actual["a"].dtype, np.dtype("=U1"))
 
     @pytest.mark.parametrize(
         "decoded_fn, encoded_fn",

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2272,11 +2272,6 @@ class ZarrBase(CFEncodedBase):
             )
 
     def save(self, dataset, store_target, **kwargs):  # type: ignore[override]
-        if have_zarr_v3 and zarr.config.config["default_zarr_version"] == 3:
-            for k, v in dataset.variables.items():
-                if v.dtype.kind in ("M",):
-                    pytest.skip(reason=f"Unsupported dtype {v} for variable: {k}")
-
         return dataset.to_zarr(store=store_target, **kwargs, **self.version_kwargs)
 
     @contextlib.contextmanager
@@ -5353,13 +5348,13 @@ class TestDataArrayToNetCDF:
 class TestDataArrayToZarr:
 
     def skip_if_zarr_python_3_and_zip_store(self, store) -> None:
-        if isinstance(store, zarr.storage.ZipStore):
+        if isinstance(store, zarr.storage.zip.ZipStore):
             pytest.skip(
                 reason="zarr-python 3.x doesn't support reopening ZipStore with a new mode."
             )
 
     def test_dataarray_to_zarr_no_name(self, tmp_store) -> None:
-        skip_if_zarr_format_3(tmp_store)
+        self.skip_if_zarr_python_3_and_zip_store(tmp_store)
         original_da = DataArray(np.arange(1, 13).reshape((3, 4)))
 
         original_da.to_zarr(tmp_store)
@@ -5368,7 +5363,7 @@ class TestDataArrayToZarr:
             assert_identical(original_da, loaded_da)
 
     def test_dataarray_to_zarr_with_name(self, tmp_store) -> None:
-        skip_if_zarr_format_3(tmp_store)
+        self.skip_if_zarr_python_3_and_zip_store(tmp_store)
         original_da = DataArray(np.arange(12).reshape((3, 4)) + 1, name="test")
 
         original_da.to_zarr(tmp_store)
@@ -5377,7 +5372,7 @@ class TestDataArrayToZarr:
             assert_identical(original_da, loaded_da)
 
     def test_dataarray_to_zarr_coord_name_clash(self, tmp_store) -> None:
-        skip_if_zarr_format_3(tmp_store)
+        self.skip_if_zarr_python_3_and_zip_store(tmp_store)
         original_da = DataArray(
             np.arange(12).reshape((3, 4)) + 1, dims=["x", "y"], name="x"
         )
@@ -5388,7 +5383,7 @@ class TestDataArrayToZarr:
             assert_identical(original_da, loaded_da)
 
     def test_open_dataarray_options(self, tmp_store) -> None:
-        skip_if_zarr_format_3(tmp_store)
+        self.skip_if_zarr_python_3_and_zip_store(tmp_store)
         data = DataArray(np.arange(5) + 1, coords={"y": ("x", range(1, 6))}, dims=["x"])
 
         data.to_zarr(tmp_store)

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1224,6 +1224,7 @@ class CFEncodedBase(DatasetIOBase):
                 assert "coordinates" not in ds["lon"].encoding
 
     def test_roundtrip_endian(self) -> None:
+        skip_if_zarr_format_3("zarr v3 has not implemented endian support yet")
         ds = Dataset(
             {
                 "x": np.arange(3, 10, dtype=">i2"),

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -2272,6 +2272,11 @@ class ZarrBase(CFEncodedBase):
             )
 
     def save(self, dataset, store_target, **kwargs):  # type: ignore[override]
+        if have_zarr_v3 and zarr.config.config["default_zarr_version"] == 3:
+            for k, v in dataset.variables.items():
+                if v.dtype.kind in ("M",):
+                    pytest.skip(reason=f"Unsupported dtype {v} for variable: {k}")
+
         return dataset.to_zarr(store=store_target, **kwargs, **self.version_kwargs)
 
     @contextlib.contextmanager

--- a/xarray/tests/test_backends.py
+++ b/xarray/tests/test_backends.py
@@ -1333,6 +1333,8 @@ class CFEncodedBase(DatasetIOBase):
         with self.roundtrip(ds) as actual:
             assert "_FillValue" not in actual.x.encoding
 
+    # TODO: decide if this test is really necessary
+    # _FillValue is not a valid encoding for Zarr
     def test_explicitly_omit_fill_value_via_encoding_kwarg(self) -> None:
         ds = Dataset({"x": ("y", [np.pi, -np.pi])})
         kwargs = dict(encoding={"x": {"_FillValue": None}})


### PR DESCRIPTION
This branch combines

- #2
- #3 
- #4 
- #5 
- #6 
- #7 
- #8 

It was created off 118e50eb5f2495eb9c5f0b366f39a8a1929af8b6 as follows

```
git checkout fix/zarr-v3 
# or git checkout -b fix/zarr-v3 118e50eb5f2495eb9c5f0b366f39a8a1929af8b6
git merge ryan/fix/zarr-v3-2 ryan/fix/zarr-v3-3 ryan/fix/zarr-v3-4 ryan/fix/zarr-v3-5 ryan/fix/zarr-v3-6 ryan/fix/zarr-v3-7 ryan/fix/zarr-v3-8
```

Against the zarr `xarray-compat` branch, all of the V3 tests are passing (or are correctly skipped due to truly unsupported features) :tada:

```
$ pytest -v xarray/tests/test_backends.py -k Zarr
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_roundtrip_object_dtype[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_write_persistence_modes[2-None] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_write_persistence_modes[2-group1] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_check_encoding_is_consistent_after_append[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_with_new_variable[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_append_with_append_dim_no_overwrite[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDictStore::test_to_zarr_append_compute_false_roundtrip[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_roundtrip_object_dtype[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_write_persistence_modes[2-None] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_write_persistence_modes[2-group1] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_check_encoding_is_consistent_after_append[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_append_with_new_variable[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_append_with_append_dim_no_overwrite[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrDirectoryStore::test_to_zarr_append_compute_false_roundtrip[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_roundtrip_object_dtype[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_write_persistence_modes[2-None] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_write_persistence_modes[2-group1] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_check_encoding_is_consistent_after_append[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_append_with_new_variable[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_append_with_append_dim_no_overwrite[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::TestZarrWriteEmpty::test_to_zarr_append_compute_false_roundtrip[2] - ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
FAILED xarray/tests/test_backends.py::test_zarr_storage_options - TypeError: Unsupported type for store_like: 'FSMap'
```

There is still something wrong with V2 dtypes. I'm not going to have the bandwidth to sort that out before the Icechunk launch.